### PR TITLE
Fix a plus/minus sign in the Okada module

### DIFF
--- a/Okada.jl
+++ b/Okada.jl
@@ -681,7 +681,7 @@ module Okada
 		u = (eta.*cos.(dip) + q.*sin.(dip)).*q./(R.*(R + xi)) + cos.(dip).*xi.*q./(R.*(R + eta)) - I5.(xi,eta,q,dip,nu,R,db).*sin.(dip).^2;
 		#k = findall(q.!=0);
 		if q!=0
-			u = u + cos.(dip).*atan.(xi.*eta./(q.*R));
+			u = u - cos.(dip).*atan.(xi.*eta./(q.*R));
 		end
 		#u[k] = u[k] - cos.(dip).*atan.(xi[k].*eta[k]./(q[k].*R[k]));
 		return u


### PR DESCRIPTION
A sign error in Okada has been fixed. 
This affects only the calculation of the displacements due to tensile faults.

Please check the consistency with the original MATLAB files (see `function uz_tf`).
https://jp.mathworks.com/matlabcentral/fileexchange/25982-okada-surface-deformation-due-to-a-finite-rectangular-source