### PR TITLE
Revise Okada's formulae codes

### DIFF
--- a/Okada.jl
+++ b/Okada.jl
@@ -147,7 +147,7 @@ module Okada
 		Created: 1997
 		Updated: 2014-05-24
 		"""
-	function okada85(e,n,depth,strike,dip,L,W,rake,slip,U3; nu=0.25, nargout::Integer=3)
+	function okada85(e::Real,n::Real,depth,strike,dip,L,W,rake,slip,U3; nu=0.25, nargout::Integer=3)
 
 		## arg check
         any(nargout .== [1,3,9,12]) || error("kwarg 'nargout' must be either 1, 3, 9, or 12.")
@@ -245,6 +245,11 @@ module Okada
             uzz = -(uee + unn)*nu/(1-nu)
 		    return [ue,un,uz,uee,une,uze,uen,unn,uzn,uez,unz,uzz]
 		end
+	end
+
+	function okada85(e::AbstractArray,n::AbstractArray,depth,strike,dip,L,W,rake,slip,U3; kwargs...)
+		size(e) != size(n) && error("The sizes of E and N must be the same. \n size(E) = $(size(e)) \n size(N) = $(size(n))")
+		return map(x->reshape(x,size(e)), collect.(zip(okada85.(e,n,depth,strike,dip,L,W,rake,slip,U3; kwargs...)...)))
 	end
 
 	import Test

--- a/Okada.jl
+++ b/Okada.jl
@@ -19,8 +19,8 @@
 """
 module Okada
 
-	export Okada85,testOkada,Okada85vert,Okada85Dis
-
+	export Okada85, testOkada
+	
 	#	Translated to Julia By Cyprien Bosserelle 2020
 	#	References:
 	#	   Aki K., and P. G. Richards, Quantitative seismology, Freemann & Co,
@@ -147,258 +147,111 @@ module Okada
 		Created: 1997
 		Updated: 2014-05-24
 		"""
-	function Okada85(e,n,depth,strike,dip,L,W,rake,slip,U3; nu=0.25)
+	function Okada85(e,n,depth,strike,dip,L,W,rake,slip,U3; nu=0.25, nargout::Integer=3)
+
+		## arg check
+        any(nargout .== [1,3,9,12]) || error("kwarg 'nargout' must be either 1, 3, 9, or 12.")
 
 		if(depth<W*0.5*sind(dip))
 			warn("Depth too shallow! ")
 		end
 
-		strike = strike*pi/180;	# converting STRIKE in radian
-		dip = dip*pi/180;	# converting DIP in radian ('delta' in Okada's equations)
-		rake = rake*pi/180;	#converting RAKE in radian
+		strike = strike*pi/180  # converting STRIKE in radian
+		dip = dip*pi/180        # converting DIP in radian ('delta' in Okada's equations)
+		rake = rake*pi/180      # converting RAKE in radian
 
 		# Defines dislocation in the fault plane system
-		U1 = cos(rake).*slip;
-		U2 = sin(rake).*slip;
+		U1 = cos(rake)*slip
+		U2 = sin(rake)*slip
 		# Converts fault coordinates (E,N,DEPTH) relative to centroid
 		# into Okada's reference system (X,Y,D)
-		 d = depth + sin(dip).*W/2;	# d is fault's top edge
-		#d = depth - sin(dip).*W/2;
-		ec = e .+ cos(strike).*cos(dip).*W/2;
-		nc = n .- sin(strike).*cos(dip).*W/2;
-		x = cos(strike).*nc .+ sin(strike).*ec .+ L/2;
-		y = sin(strike).*nc .- cos(strike).*ec .+ cos(dip).*W;
+		d = depth + sin(dip)*W/2  # d is fault's top edge
+		ec = e + cos(strike)*cos(dip)*W/2
+		nc = n - sin(strike)*cos(dip)*W/2
+		x = cos(strike)*nc + sin(strike)*ec + L/2
+		y = sin(strike)*nc - cos(strike)*ec + cos(dip)*W
 		# Variable substitution (independent from xi and eta)
-		p = y.*cos(dip) .+ d.*sin(dip);
-		q = y.*sin(dip) .- d.*cos(dip);
+		p = y*cos(dip) + d*sin(dip)
+		q = y*sin(dip) - d*cos(dip)
 
 		# Displacements
-		ux = ( -U1/(2*pi) .* chinnery_ux_ss.(x,p,L,W,q,dip,nu) # strike-slip
-			.- U2/(2*pi) .* chinnery_ux_ds.(x,p,L,W,q,dip,nu) # dip-slip
-			.+ U3/(2*pi) .* chinnery_ux_tf.(x,p,L,W,q,dip,nu)); # tensile fault
+		ux = (-U1/(2*pi) * chinnery(ux_ss,x,p,L,W,q,dip,nu) # strike-slip
+		      -U2/(2*pi) * chinnery(ux_ds,x,p,L,W,q,dip,nu) # dip-slip
+		      +U3/(2*pi) * chinnery(ux_tf,x,p,L,W,q,dip,nu)) # tensile fault
 
-		uy = ( -U1/(2*pi) .* chinnery_uy_ss.(x,p,L,W,q,dip,nu) # strike-slip
-			.- U2/(2*pi) .* chinnery_uy_ds.(x,p,L,W,q,dip,nu) # dip-slip
-			.+ U3/(2*pi) .* chinnery_uy_tf.(x,p,L,W,q,dip,nu)); # tensile fault
+		uy = (-U1/(2*pi) * chinnery(uy_ss,x,p,L,W,q,dip,nu) # strike-slip
+		      -U2/(2*pi) * chinnery(uy_ds,x,p,L,W,q,dip,nu) # dip-slip
+		      +U3/(2*pi) * chinnery(uy_tf,x,p,L,W,q,dip,nu)) # tensile fault
 
-		uz = ( -U1/(2*pi) .* chinnery_uz_ss.(x,p,L,W,q,dip,nu) # strike-slip
-			.- U2/(2*pi) .* chinnery_uz_ds.(x,p,L,W,q,dip,nu) # dip-slip
-			.+ U3/(2*pi) .* chinnery_uz_tf.(x,p,L,W,q,dip,nu)); # tensile fault
+		uz = (-U1/(2*pi) * chinnery(uz_ss,x,p,L,W,q,dip,nu) # strike-slip
+		      -U2/(2*pi) * chinnery(uz_ds,x,p,L,W,q,dip,nu) # dip-slip
+		      +U3/(2*pi) * chinnery(uz_tf,x,p,L,W,q,dip,nu)) # tensile fault
 		# Rotation from Okada's axes to geographic
-		ue = sin(strike).*ux .- cos(strike).*uy;
-		un = cos(strike).*ux .+ sin(strike).*uy;
+		ue = sin(strike)*ux - cos(strike)*uy
+		un = cos(strike)*ux + sin(strike)*uy
 
+		if nargout == 1
+			return uz
+		elseif nargout == 3
+			return [ue,un,uz]
+		end
 
 		# Tilt
-		uzx =( -U1/(2*pi) .* chinnery_uzx_ss.(x,p,L,W,q,dip,nu) # strike-slip
-			 .- U2/(2*pi) .* chinnery_uzx_ds.(x,p,L,W,q,dip,nu) # dip-slip
-			 .+ U3/(2*pi) .* chinnery_uzx_tf.(x,p,L,W,q,dip,nu)); # tensile fault
+		uzx =(-U1/(2*pi) * chinnery(uzx_ss,x,p,L,W,q,dip,nu) # strike-slip
+		      -U2/(2*pi) * chinnery(uzx_ds,x,p,L,W,q,dip,nu) # dip-slip
+		      +U3/(2*pi) * chinnery(uzx_tf,x,p,L,W,q,dip,nu)) # tensile fault
 
-		uzy =( -U1/(2*pi) .* chinnery_uzy_ss.(x,p,L,W,q,dip,nu) # strike-slip
-			 .- U2/(2*pi) .* chinnery_uzy_ds.(x,p,L,W,q,dip,nu) # dip-slip
-			 .+ U3/(2*pi) .* chinnery_uzy_tf.(x,p,L,W,q,dip,nu)); # tensile fault
+		uzy =(-U1/(2*pi) * chinnery(uzy_ss,x,p,L,W,q,dip,nu) # strike-slip
+		      -U2/(2*pi) * chinnery(uzy_ds,x,p,L,W,q,dip,nu) # dip-slip
+		      +U3/(2*pi) * chinnery(uzy_tf,x,p,L,W,q,dip,nu)) # tensile fault
 
 		# Rotation from Okada's axes to geographic
-		uze = -sin(strike).*uzx .+ cos(strike).*uzy;
-		uzn = -cos(strike).*uzx .- sin(strike).*uzy;``
+		uze = -sin(strike)*uzx + cos(strike)*uzy
+		uzn = -cos(strike)*uzx - sin(strike)*uzy
 
 		# Strain
-		uxx = ( -U1/(2*pi) .* chinnery_uxx_ss.(x,p,L,W,q,dip,nu) # strike-slip
-				- U2/(2*pi) .* chinnery_uxx_ds.(x,p,L,W,q,dip,nu) # dip-slip
-				+ U3/(2*pi) .* chinnery_uxx_tf.(x,p,L,W,q,dip,nu)); # tensile fault
+		uxx = (-U1/(2*pi) * chinnery(uxx_ss,x,p,L,W,q,dip,nu) # strike-slip
+		       -U2/(2*pi) * chinnery(uxx_ds,x,p,L,W,q,dip,nu) # dip-slip
+		       +U3/(2*pi) * chinnery(uxx_tf,x,p,L,W,q,dip,nu)) # tensile fault
 
-		uxy = ( -U1/(2*pi) .* chinnery_uxy_ss.(x,p,L,W,q,dip,nu) # strike-slip
-				.- U2/(2*pi) .* chinnery_uxy_ds.(x,p,L,W,q,dip,nu) # dip-slip
-				.+ U3/(2*pi) .* chinnery_uxy_tf.(x,p,L,W,q,dip,nu)); # tensile fault
+		uxy = (-U1/(2*pi) * chinnery(uxy_ss,x,p,L,W,q,dip,nu) # strike-slip
+		       -U2/(2*pi) * chinnery(uxy_ds,x,p,L,W,q,dip,nu) # dip-slip
+		       +U3/(2*pi) * chinnery(uxy_tf,x,p,L,W,q,dip,nu)) # tensile fault
 
-		uyx = ( -U1/(2*pi) .* chinnery_uyx_ss.(x,p,L,W,q,dip,nu) # strike-slip
-			 .- U2/(2*pi) .* chinnery_uyx_ds.(x,p,L,W,q,dip,nu) # dip-slip
-			.+ U3/(2*pi) .* chinnery_uyx_tf.(x,p,L,W,q,dip,nu)); # tensile fault
+		uyx = (-U1/(2*pi) * chinnery(uyx_ss,x,p,L,W,q,dip,nu) # strike-slip
+		       -U2/(2*pi) * chinnery(uyx_ds,x,p,L,W,q,dip,nu) # dip-slip
+		       +U3/(2*pi) * chinnery(uyx_tf,x,p,L,W,q,dip,nu)) # tensile fault
 
-		uyy = ( -U1/(2*pi) .* chinnery_uyy_ss.(x,p,L,W,q,dip,nu) # strike-slip
-				.- U2/(2*pi) .* chinnery_uyy_ds.(x,p,L,W,q,dip,nu) # dip-slip
-				.+ U3/(2*pi) .* chinnery_uyy_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-
-		# Rotation from Okada's axes to geographic
-		unn = cos(strike) .^ 2 .* uxx .+ sin(2*strike).*(uxy .+ uyx)/2 + sin(strike).^2 .*uyy;
-		une = sin(2*strike) .* (uxx .- uyy)/2 + sin(strike).^2 .* uyx .- cos(strike).^2 .*uxy;
-		uen = sin(2*strike) .* (uxx .- uyy)/2 - cos(strike).^2 .* uyx .+ sin(strike).^2 .*uxy;
-		uee = sin(strike).^2 .* uxx .- sin(2*strike).*(uyx .+ uxy)./2 .+ cos(strike).^2 .*uyy;
-
-
-		return ue,un,uz,uze,uzn,unn,une,uen,uee
-# {ue, un, uz, uze, uzn, unn, une, uen, uee}
-
-
-	end
-
-	function Okada85vert(e,n,depth,strike,dip,L,W,rake,slip,U3; nu=0.25)
-
-		strike = strike*pi/180;	# converting STRIKE in radian
-		dip = dip*pi/180;	# converting DIP in radian ('delta' in Okada's equations)
-		rake = rake*pi/180;	#converting RAKE in radian
-
-		# Defines dislocation in the fault plane system
-		U1 = cos(rake).*slip;
-		U2 = sin(rake).*slip;
-		# Converts fault coordinates (E,N,DEPTH) relative to centroid
-		# into Okada's reference system (X,Y,D)
-		d = depth + sin(dip).*W/2;	# d is fault's top edge
-		#d = depth - sin(dip).*W/2;	# d is fault's top edge
-		ec = e .+ cos(strike).*cos(dip).*W/2;
-		nc = n .- sin(strike).*cos(dip).*W/2;
-		x = cos(strike).*nc .+ sin(strike).*ec .+ L/2;
-		y = sin(strike).*nc .- cos(strike).*ec .+ cos(dip).*W;
-		# Variable substitution (independent from xi and eta)
-		p = y.*cos(dip) .+ d.*sin(dip);
-		q = y.*sin(dip) .- d.*cos(dip);
-
-		# Displacements
-		ux = ( -U1/(2*pi) .* chinnery_ux_ss.(x,p,L,W,q,dip,nu) # strike-slip
-			.- U2/(2*pi) .* chinnery_ux_ds.(x,p,L,W,q,dip,nu) # dip-slip
-			.+ U3/(2*pi) .* chinnery_ux_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-
-		uy = ( -U1/(2*pi) .* chinnery_uy_ss.(x,p,L,W,q,dip,nu) # strike-slip
-			.- U2/(2*pi) .* chinnery_uy_ds.(x,p,L,W,q,dip,nu) # dip-slip
-			.+ U3/(2*pi) .* chinnery_uy_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-
-		uz = ( -U1/(2*pi) .* chinnery_uz_ss.(x,p,L,W,q,dip,nu) # strike-slip
-			.- U2/(2*pi) .* chinnery_uz_ds.(x,p,L,W,q,dip,nu) # dip-slip
-			.+ U3/(2*pi) .* chinnery_uz_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-		# # Rotation from Okada's axes to geographic
-		# ue = sin(strike).*ux .- cos(strike).*uy;
-		# un = cos(strike).*ux .+ sin(strike).*uy;
-		#
-		#
-		# # Tilt
-		# uzx =( -U1/(2*pi) .* chinnery_uzx_ss.(x,p,L,W,q,dip,nu) # strike-slip
-		# 	 .- U2/(2*pi) .* chinnery_uzx_ds.(x,p,L,W,q,dip,nu) # dip-slip
-		# 	 .+ U3/(2*pi) .* chinnery_uzx_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-		#
-		# uzy =( -U1/(2*pi) .* chinnery_uzy_ss.(x,p,L,W,q,dip,nu) # strike-slip
-		# 	 .- U2/(2*pi) .* chinnery_uzy_ds.(x,p,L,W,q,dip,nu) # dip-slip
-		# 	 .+ U3/(2*pi) .* chinnery_uzy_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-		#
-		# # Rotation from Okada's axes to geographic
-		# uze = -sin(strike).*uzx .+ cos(strike).*uzy;
-		# uzn = -cos(strike).*uzx .- sin(strike).*uzy;``
-		#
-		# # Strain
-		# uxx = ( -U1/(2*pi) .* chinnery_uxx_ss.(x,p,L,W,q,dip,nu) # strike-slip
-		# 		- U2/(2*pi) .* chinnery_uxx_ds.(x,p,L,W,q,dip,nu) # dip-slip
-		# 		+ U3/(2*pi) .* chinnery_uxx_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-		#
-		# uxy = ( -U1/(2*pi) .* chinnery_uxy_ss.(x,p,L,W,q,dip,nu) # strike-slip
-		# 		.- U2/(2*pi) .* chinnery_uxy_ds.(x,p,L,W,q,dip,nu) # dip-slip
-		# 		.+ U3/(2*pi) .* chinnery_uxy_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-		#
-		# uyx = ( -U1/(2*pi) .* chinnery_uyx_ss.(x,p,L,W,q,dip,nu) # strike-slip
-		# 	 .- U2/(2*pi) .* chinnery_uyx_ds.(x,p,L,W,q,dip,nu) # dip-slip
-		# 	.+ U3/(2*pi) .* chinnery_uyx_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-		#
-		# uyy = ( -U1/(2*pi) .* chinnery_uyy_ss.(x,p,L,W,q,dip,nu) # strike-slip
-		# 		.- U2/(2*pi) .* chinnery_uyy_ds.(x,p,L,W,q,dip,nu) # dip-slip
-		# 		.+ U3/(2*pi) .* chinnery_uyy_tf.(x,p,L,W,q,dip,nu)); # tensile fault
+		uyy = (-U1/(2*pi) * chinnery(uyy_ss,x,p,L,W,q,dip,nu) # strike-slip
+		       -U2/(2*pi) * chinnery(uyy_ds,x,p,L,W,q,dip,nu) # dip-slip
+			   +U3/(2*pi) * chinnery(uyy_tf,x,p,L,W,q,dip,nu)) # tensile fault			   
+		## TM thinks these signs are opposite
+		uxx = -uxx
+		uxy = -uxy
+		uyx = -uyx
+		uyy = -uyy
 
 		# Rotation from Okada's axes to geographic
-		# unn = cos(strike) .^ 2 .* uxx .+ sin(2*strike).*(uxy .+ uyx)/2 + sin(strike).^2 .*uyy;
-		# une = sin(2*strike) .* (uxx .- uyy)/2 + sin(strike).^2 .* uyx .- cos(strike).^2 .*uxy;
-		# uen = sin(2*strike) .* (uxx .- uyy)/2 - cos(strike).^2 .* uyx .+ sin(strike).^2 .*uxy;
-		# uee = sin(strike).^2 .* uxx .- sin(2*strike).*(uyx .+ uxy)./2 .+ cos(strike).^2 .*uyy;
+		unn = cos(strike)^2*uxx + sin(2*strike)*(uxy+uyx)/2 + sin(strike)^2*uyy
+		une = sin(2*strike)*(uxx-uyy)/2 + sin(strike)^2*uyx - cos(strike)^2*uxy
+		uen = sin(2*strike)*(uxx-uyy)/2 - cos(strike)^2*uyx + sin(strike)^2*uxy
+		uee = sin(strike)^2*uxx - sin(2*strike)*(uyx+uxy)/2 + cos(strike)^2*uyy
 
-
-		return uz
-# {ue, un, uz, uze, uzn, unn, une, uen, uee}
-
-
+        if nargout == 9
+		    return [ue,un,uz,uze,uzn,unn,une,uen,uee]
+		elseif nargout == 12
+            unz = -uzn
+            uez = -uze
+            uzz = -(uee + unn)*nu/(1-nu)
+		    return [ue,un,uz,uee,une,uze,uen,unn,uzn,uez,unz,uzz]
+		end
 	end
-	function Okada85Dis(e,n,depth,strike,dip,L,W,rake,slip,U3; nu=0.25)
 
-		strike = strike*pi/180;	# converting STRIKE in radian
-		dip = dip*pi/180;	# converting DIP in radian ('delta' in Okada's equations)
-		rake = rake*pi/180;	#converting RAKE in radian
-
-		# Defines dislocation in the fault plane system
-		U1 = cos(rake).*slip;
-		U2 = sin(rake).*slip;
-		# Converts fault coordinates (E,N,DEPTH) relative to centroid
-		# into Okada's reference system (X,Y,D)
-		d = depth + sin(dip).*W/2;	# d is fault's top edge
-		#d = depth - sin(dip).*W/2;	# d is fault's top edge
-		ec = e .+ cos(strike).*cos(dip).*W/2;
-		nc = n .- sin(strike).*cos(dip).*W/2;
-		x = cos(strike).*nc .+ sin(strike).*ec .+ L/2;
-		y = sin(strike).*nc .- cos(strike).*ec .+ cos(dip).*W;
-		# Variable substitution (independent from xi and eta)
-		p = y.*cos(dip) .+ d.*sin(dip);
-		q = y.*sin(dip) .- d.*cos(dip);
-
-		# Displacements
-		ux = ( -U1/(2*pi) .* chinnery_ux_ss.(x,p,L,W,q,dip,nu) # strike-slip
-			.- U2/(2*pi) .* chinnery_ux_ds.(x,p,L,W,q,dip,nu) # dip-slip
-			.+ U3/(2*pi) .* chinnery_ux_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-
-		uy = ( -U1/(2*pi) .* chinnery_uy_ss.(x,p,L,W,q,dip,nu) # strike-slip
-			.- U2/(2*pi) .* chinnery_uy_ds.(x,p,L,W,q,dip,nu) # dip-slip
-			.+ U3/(2*pi) .* chinnery_uy_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-
-		uz = ( -U1/(2*pi) .* chinnery_uz_ss.(x,p,L,W,q,dip,nu) # strike-slip
-			.- U2/(2*pi) .* chinnery_uz_ds.(x,p,L,W,q,dip,nu) # dip-slip
-			.+ U3/(2*pi) .* chinnery_uz_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-		# # Rotation from Okada's axes to geographic
-		ue = sin(strike).*ux .- cos(strike).*uy;
-		un = cos(strike).*ux .+ sin(strike).*uy;
-		#
-		#
-		# # Tilt
-		# uzx =( -U1/(2*pi) .* chinnery_uzx_ss.(x,p,L,W,q,dip,nu) # strike-slip
-		# 	 .- U2/(2*pi) .* chinnery_uzx_ds.(x,p,L,W,q,dip,nu) # dip-slip
-		# 	 .+ U3/(2*pi) .* chinnery_uzx_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-		#
-		# uzy =( -U1/(2*pi) .* chinnery_uzy_ss.(x,p,L,W,q,dip,nu) # strike-slip
-		# 	 .- U2/(2*pi) .* chinnery_uzy_ds.(x,p,L,W,q,dip,nu) # dip-slip
-		# 	 .+ U3/(2*pi) .* chinnery_uzy_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-		#
-		# # Rotation from Okada's axes to geographic
-		# uze = -sin(strike).*uzx .+ cos(strike).*uzy;
-		# uzn = -cos(strike).*uzx .- sin(strike).*uzy;``
-		#
-		# # Strain
-		# uxx = ( -U1/(2*pi) .* chinnery_uxx_ss.(x,p,L,W,q,dip,nu) # strike-slip
-		# 		- U2/(2*pi) .* chinnery_uxx_ds.(x,p,L,W,q,dip,nu) # dip-slip
-		# 		+ U3/(2*pi) .* chinnery_uxx_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-		#
-		# uxy = ( -U1/(2*pi) .* chinnery_uxy_ss.(x,p,L,W,q,dip,nu) # strike-slip
-		# 		.- U2/(2*pi) .* chinnery_uxy_ds.(x,p,L,W,q,dip,nu) # dip-slip
-		# 		.+ U3/(2*pi) .* chinnery_uxy_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-		#
-		# uyx = ( -U1/(2*pi) .* chinnery_uyx_ss.(x,p,L,W,q,dip,nu) # strike-slip
-		# 	 .- U2/(2*pi) .* chinnery_uyx_ds.(x,p,L,W,q,dip,nu) # dip-slip
-		# 	.+ U3/(2*pi) .* chinnery_uyx_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-		#
-		# uyy = ( -U1/(2*pi) .* chinnery_uyy_ss.(x,p,L,W,q,dip,nu) # strike-slip
-		# 		.- U2/(2*pi) .* chinnery_uyy_ds.(x,p,L,W,q,dip,nu) # dip-slip
-		# 		.+ U3/(2*pi) .* chinnery_uyy_tf.(x,p,L,W,q,dip,nu)); # tensile fault
-
-		# Rotation from Okada's axes to geographic
-		# unn = cos(strike) .^ 2 .* uxx .+ sin(2*strike).*(uxy .+ uyx)/2 + sin(strike).^2 .*uyy;
-		# une = sin(2*strike) .* (uxx .- uyy)/2 + sin(strike).^2 .* uyx .- cos(strike).^2 .*uxy;
-		# uen = sin(2*strike) .* (uxx .- uyy)/2 - cos(strike).^2 .* uyx .+ sin(strike).^2 .*uxy;
-		# uee = sin(strike).^2 .* uxx .- sin(2*strike).*(uyx .+ uxy)./2 .+ cos(strike).^2 .*uyy;
-
-
-		return ue, un, uz
-# {ue, un, uz, uze, uzn, unn, une, uen, uee}
-
-
-	end
 	import Test
-
-
 	function runtest(x,y,d,dip,L,W,rake,slip,u3,ref, precision)
 
-	    ue,un,uz,uze,uzn,unn,une,uen,uee=Okada85(x-L/2,y-cosd(dip)*W/2,d-sind(dip)*W/2,90,dip,L,W,rake,slip,u3)
-	    return Test.@test [ue,un,uz,-uee,-uen,-une,-unn,uze,uzn] ≈ ref atol=precision
+	    ue,un,uz,uze,uzn,unn,une,uen,uee=Okada85(x-L/2,y-cosd(dip)*W/2,d-sind(dip)*W/2,90,dip,L,W,rake,slip,u3; nargout=9)
+	    return Test.@test [ue,un,uz,uee,uen,une,unn,uze,uzn] ≈ ref atol=precision
 	end
 
 	"""
@@ -489,170 +342,32 @@ module Okada
 
 	 In Julia this seem like a very slow way of doing things becasue it may prevent the functions to be compiled
 	"""
-	function chinnery(f,x,p,L,W,q,dip,nu)
-		u = eval(Symbol(f)).(x,p,q,dip,nu) - eval(Symbol(f)).(x,p-W,q,dip,nu) - eval(Symbol(f)).(x-L,p,q,dip,nu) + eval(Symbol(f))(x-L,p-W,q,dip,nu);
-		return u
-	end
+	chinnery(f::Function, x, p, L, W, q, dip, nu) = f(x,p,q,dip,nu) - f(x,p-W,q,dip,nu) - f(x-L,p,q,dip,nu) + f(x-L,p-W,q,dip,nu)
 
-	function chinnery_ux_ss(x,p,L,W,q,dip,nu)
-		u =ux_ss.(x,p,q,dip,nu) - ux_ss.(x,p-W,q,dip,nu) - ux_ss.(x-L,p,q,dip,nu) + ux_ss.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_ux_ds(x,p,L,W,q,dip,nu)
-		u =ux_ds.(x,p,q,dip,nu) - ux_ds.(x,p-W,q,dip,nu) - ux_ds.(x-L,p,q,dip,nu) + ux_ds.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_ux_tf(x,p,L,W,q,dip,nu)
-		u =ux_tf.(x,p,q,dip,nu) - ux_tf.(x,p-W,q,dip,nu) - ux_tf.(x-L,p,q,dip,nu) + ux_tf.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uy_ss(x,p,L,W,q,dip,nu)
-		u =uy_ss.(x,p,q,dip,nu) - uy_ss.(x,p-W,q,dip,nu) - uy_ss.(x-L,p,q,dip,nu) + uy_ss.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uy_ds(x,p,L,W,q,dip,nu)
-		u =uy_ds.(x,p,q,dip,nu) - uy_ds.(x,p-W,q,dip,nu) - uy_ds.(x-L,p,q,dip,nu) + uy_ds.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uy_tf(x,p,L,W,q,dip,nu)
-		u =uy_tf.(x,p,q,dip,nu) - uy_tf.(x,p-W,q,dip,nu) - uy_tf.(x-L,p,q,dip,nu) + uy_tf.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-
-	function chinnery_uz_ss(x,p,L,W,q,dip,nu)
-		u =uz_ss.(x,p,q,dip,nu) - uz_ss.(x,p-W,q,dip,nu) - uz_ss.(x-L,p,q,dip,nu) + uz_ss.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uz_ds(x,p,L,W,q,dip,nu)
-		u =uz_ds.(x,p,q,dip,nu) - uz_ds.(x,p-W,q,dip,nu) - uz_ds.(x-L,p,q,dip,nu) + uz_ds.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uz_tf(x,p,L,W,q,dip,nu)
-		u =uz_tf.(x,p,q,dip,nu) - uz_tf.(x,p-W,q,dip,nu) - uz_tf.(x-L,p,q,dip,nu) + uz_tf.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uzx_ss(x,p,L,W,q,dip,nu)
-		u =uzx_ss.(x,p,q,dip,nu) - uzx_ss.(x,p-W,q,dip,nu) - uzx_ss.(x-L,p,q,dip,nu) + uzx_ss.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uzx_ds(x,p,L,W,q,dip,nu)
-		u =uzx_ds.(x,p,q,dip,nu) - uzx_ds.(x,p-W,q,dip,nu) - uzx_ds.(x-L,p,q,dip,nu) + uzx_ds.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uzx_tf(x,p,L,W,q,dip,nu)
-		u =uzx_tf.(x,p,q,dip,nu) - uzx_tf.(x,p-W,q,dip,nu) - uzx_tf.(x-L,p,q,dip,nu) + uzx_tf.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uzy_ss(x,p,L,W,q,dip,nu)
-		u =uzy_ss.(x,p,q,dip,nu) - uzy_ss.(x,p-W,q,dip,nu) - uzy_ss.(x-L,p,q,dip,nu) + uzy_ss.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uzy_ds(x,p,L,W,q,dip,nu)
-		u =uzy_ds.(x,p,q,dip,nu) - uzy_ds.(x,p-W,q,dip,nu) - uzy_ds.(x-L,p,q,dip,nu) + uzy_ds.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uzy_tf(x,p,L,W,q,dip,nu)
-		u =uzy_tf.(x,p,q,dip,nu) - uzy_tf.(x,p-W,q,dip,nu) - uzy_tf.(x-L,p,q,dip,nu) + uzy_tf.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uxx_ss(x,p,L,W,q,dip,nu)
-		u =uxx_ss.(x,p,q,dip,nu) - uxx_ss.(x,p-W,q,dip,nu) - uxx_ss.(x-L,p,q,dip,nu) + uxx_ss.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uxx_ds(x,p,L,W,q,dip,nu)
-		u =uxx_ds.(x,p,q,dip,nu) - uxx_ds.(x,p-W,q,dip,nu) - uxx_ds.(x-L,p,q,dip,nu) + uxx_ds.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uxx_tf(x,p,L,W,q,dip,nu)
-		u =uxx_tf.(x,p,q,dip,nu) - uxx_tf.(x,p-W,q,dip,nu) - uxx_tf.(x-L,p,q,dip,nu) + uxx_tf.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uyy_ss(x,p,L,W,q,dip,nu)
-		u =uyy_ss.(x,p,q,dip,nu) - uyy_ss.(x,p-W,q,dip,nu) - uyy_ss.(x-L,p,q,dip,nu) + uyy_ss.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uyy_ds(x,p,L,W,q,dip,nu)
-		u =uyy_ds.(x,p,q,dip,nu) - uyy_ds.(x,p-W,q,dip,nu) - uyy_ds.(x-L,p,q,dip,nu) + uyy_ds.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uyy_tf(x,p,L,W,q,dip,nu)
-		u =uyy_tf.(x,p,q,dip,nu) - uyy_tf.(x,p-W,q,dip,nu) - uyy_tf.(x-L,p,q,dip,nu) + uyy_tf.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uxy_ss(x,p,L,W,q,dip,nu)
-		u =uxy_ss.(x,p,q,dip,nu) - uxy_ss.(x,p-W,q,dip,nu) - uxy_ss.(x-L,p,q,dip,nu) + uxy_ss.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uxy_ds(x,p,L,W,q,dip,nu)
-		u =uxy_ds.(x,p,q,dip,nu) - uxy_ds.(x,p-W,q,dip,nu) - uxy_ds.(x-L,p,q,dip,nu) + uxy_ds.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uxy_tf(x,p,L,W,q,dip,nu)
-		u =uxy_tf.(x,p,q,dip,nu) - uxy_tf.(x,p-W,q,dip,nu) - uxy_tf.(x-L,p,q,dip,nu) + uxy_tf.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uyx_ss(x,p,L,W,q,dip,nu)
-		u =uyx_ss.(x,p,q,dip,nu) - uyx_ss.(x,p-W,q,dip,nu) - uyx_ss.(x-L,p,q,dip,nu) + uyx_ss.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uyx_ds(x,p,L,W,q,dip,nu)
-		u =uyx_ds.(x,p,q,dip,nu) - uyx_ds.(x,p-W,q,dip,nu) - uyx_ds.(x-L,p,q,dip,nu) + uyx_ds.(x-L,p-W,q,dip,nu);
-		return u
-	end
-
-	function chinnery_uyx_tf(x,p,L,W,q,dip,nu)
-		u =uyx_tf.(x,p,q,dip,nu) - uyx_tf.(x,p-W,q,dip,nu) - uyx_tf.(x-L,p,q,dip,nu) + uyx_tf.(x-L,p-W,q,dip,nu);
-		return u
-	end
 	"""
 	Displacement subfunctions
 	strike-slip displacement subfunctions [equation (25) p. 1144]
 	"""
 	function ux_ss(xi,eta,q,dip,nu)
-		R = sqrt.(xi.^2 + eta.^2 + q.^2);
-		u = xi.*q./(R.*(R + eta)) + I1(xi,eta,q,dip,nu,R).*sin(dip);
-		k = findall(q.!=0);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		u = xi*q/(R*(R + eta)) + I1(xi,eta,q,dip,nu,R)*sin(dip)
+		k = findall(q.!=0)
 		if q!=0
-			u = u + atan(xi.*eta./(q.*R));
+			u = u + atan(xi*eta/(q*R))
 		end
 		return u
 	end
 
 	function uy_ss(xi,eta,q,dip,nu)
-		R = sqrt.(xi.^2 + eta.^2 + q.^2);
-		u = (eta.*cos.(dip) + q.*sin.(dip)).*q./(R.*(R + eta)) + q.*cos.(dip)./(R + eta)+ I2.(eta,q,dip,nu,R).*sin.(dip);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		u = (eta*cos(dip) + q*sin(dip))*q/(R*(R + eta)) + q*cos(dip)/(R + eta)+ I2(eta,q,dip,nu,R)*sin(dip)
 		return u
 	end
 
 	function uz_ss(xi,eta,q,dip,nu)
-		R = sqrt.(xi.^2 + eta.^2 + q.^2);
-		db = eta.*sin.(dip) - q.*cos.(dip);
-		u = (eta.*sin.(dip) - q.*cos.(dip)).*q./(R.*(R + eta)) + q.*sin.(dip)./(R + eta) + I4.(db,eta,q,dip,nu,R).*sin.(dip);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		db = eta*sin(dip) - q*cos(dip)
+		u = (eta*sin(dip) - q*cos(dip))*q/(R*(R + eta)) + q*sin(dip)/(R + eta) + I4(db,eta,q,dip,nu,R)*sin(dip)
 		return u
 	end
 
@@ -660,30 +375,26 @@ module Okada
 	dip-slip displacement subfunctions [equation (26) p. 1144]
 	"""
 	function ux_ds(xi,eta,q,dip,nu)
-		R = sqrt.(xi.^2 + eta.^2 + q.^2);
-		u = q./R - I3.(eta,q,dip,nu,R).*sin.(dip).*cos.(dip);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		u = q/R - I3(eta,q,dip,nu,R)*sin(dip)*cos(dip)
 		return u
 	end
 
 	function uy_ds(xi,eta,q,dip,nu)
-		R = sqrt.(xi.^2 + eta.^2 + q.^2);
-		u = (eta.*cos.(dip) + q.*sin.(dip)).*q./(R.*(R + xi)) - I1.(xi,eta,q,dip,nu,R).*sin.(dip).*cos.(dip);
-		#k = findall(q.!=0);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		u = (eta*cos(dip) + q*sin(dip))*q/(R*(R + xi)) - I1(xi,eta,q,dip,nu,R)*sin(dip)*cos(dip)
 		if q!=0
-			u = u + cos.(dip).*atan.(xi.*eta./(q.*R));
+			u = u + cos(dip)*atan(xi*eta/(q*R))
 		end
-		#u[k] = u[k] + cos.(dip).*atan.(xi[k].*eta[k]./(q[k].*R[k]));
 		return u
 	end
 	function uz_ds(xi,eta,q,dip,nu)
-		R = sqrt.(xi.^2 + eta.^2 + q.^2);
-		db = eta.*sin.(dip) - q.*cos.(dip);
-		u = db.*q./(R.*(R + xi)) - I5.(xi,eta,q,dip,nu,R,db).*sin.(dip).*cos.(dip);
-		#k = findall(q.!=0);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		db = eta*sin(dip) - q*cos(dip)
+		u = db*q/(R*(R + xi)) - I5(xi,eta,q,dip,nu,R,db)*sin(dip)*cos(dip)
 		if q!=0
-			u = u + sin.(dip).*atan.(xi.*eta./(q.*R));
+			u = u + sin(dip)*atan(xi*eta/(q*R))
 		end
-		#u[k] = u[k] + sin.(dip).*atan.(xi[k].*eta[k]./(q[k].*R[k]));
 		return u
 	end
 
@@ -691,31 +402,27 @@ module Okada
 	tensile fault displacement subfunctions [equation (27) p. 1144]
 	"""
 	function ux_tf(xi,eta,q,dip,nu)
-		R = sqrt.(xi.^2 + eta.^2 + q.^2);
-		u = q.^2 ./(R.*(R + eta)) - I3.(eta,q,dip,nu,R).*sin.(dip).^2;
+		R = sqrt(xi^2 + eta^2 + q^2)
+		u = q^2 /(R*(R + eta)) - I3(eta,q,dip,nu,R)*sin(dip)^2
 		return u
 	end
 
 	function uy_tf(xi,eta,q,dip,nu)
-		R = sqrt.(xi.^2 + eta.^2 + q.^2);
-		u = -(eta.*sin.(dip) - q.*cos.(dip)).*q./(R.*(R + xi)) - sin.(dip).*xi.*q./(R.*(R + eta)) - I1.(xi,eta,q,dip,nu,R).*sin.(dip).^2;
-		#k = findall(q.!=0);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		u = -(eta*sin(dip) - q*cos(dip))*q/(R*(R + xi)) - sin(dip)*xi*q/(R*(R + eta)) - I1(xi,eta,q,dip,nu,R)*sin(dip)^2
 		if q!=0
-			u = u + sin.(dip).*atan.(xi.*eta./(q.*R));
+			u = u + sin(dip)*atan(xi*eta/(q*R))
 		end
-		#u[k] = u[k] + sin.(dip).*atan.(xi[k].*eta[k]./(q[k].*R[k]));
 		return u
 	end
 
 	function uz_tf(xi,eta,q,dip,nu)
-		R = sqrt.(xi.^2 + eta.^2 + q.^2);
-		db = eta.*sin.(dip) - q.*cos.(dip);
-		u = (eta.*cos.(dip) + q.*sin.(dip)).*q./(R.*(R + xi)) + cos.(dip).*xi.*q./(R.*(R + eta)) - I5.(xi,eta,q,dip,nu,R,db).*sin.(dip).^2;
-		#k = findall(q.!=0);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		db = eta*sin(dip) - q*cos(dip)
+		u = (eta*cos(dip) + q*sin(dip))*q/(R*(R + xi)) + cos(dip)*xi*q/(R*(R + eta)) - I5(xi,eta,q,dip,nu,R,db)*sin(dip)^2
 		if q!=0
-			u = u - cos.(dip).*atan.(xi.*eta./(q.*R));
+			u = u - cos(dip)*atan(xi*eta/(q*R))
 		end
-		#u[k] = u[k] - cos.(dip).*atan.(xi[k].*eta[k]./(q[k].*R[k]));
 		return u
 	end
 
@@ -723,49 +430,48 @@ module Okada
 	I... displacement subfunctions [equations (28) (29) p. 1144-1145]
 	"""
 	function I1(xi,eta,q,dip,nu,R)
-		db = eta.*sin.(dip) - q.*cos(dip);
+		db = eta*sin(dip) - q*cos(dip)
 		if cos(dip) > eps()
-			I = (1 - 2*nu) * (-xi./(cos(dip).*(R + db)))- sin(dip)./cos(dip).*I5(xi,eta,q,dip,nu,R,db);
+			I = (1 - 2*nu) * (-xi/(cos(dip)*(R + db)))- sin(dip)/cos(dip)*I5(xi,eta,q,dip,nu,R,db)
 		else
-			I = -(1 - 2*nu)/2 * xi.*q./(R + db).^2;
+			I = -(1 - 2*nu)/2 * xi*q/(R + db)^2
 		end
 		return I
 	end
 
-
-	function I2(eta,q,dip,nu,R)
-		return (1 - 2*nu) * (-log(R + eta)) - I3(eta,q,dip,nu,R);
+	function I2(eta,q,dip,nu,R) 
+		return (1 - 2*nu) * (-log(R + eta)) - I3(eta,q,dip,nu,R)
 	end
 
 	function I3(eta,q,dip,nu,R)
-		yb = eta.*cos(dip) + q.*sin(dip);
-		db = eta.*sin(dip) - q.*cos(dip);
+		yb = eta*cos(dip) + q*sin(dip)
+		db = eta*sin(dip) - q*cos(dip)
 		if cos(dip) > eps()
-			I = (1 - 2*nu) * (yb./(cos(dip)*(R + db)) - log(R + eta)) + sin(dip)./cos(dip) * I4(db,eta,q,dip,nu,R);
+			I = (1 - 2*nu) * (yb/(cos(dip)*(R + db)) - log(R + eta)) + sin(dip)/cos(dip) * I4(db,eta,q,dip,nu,R)
 		else
-			I = (1 - 2*nu)/2 * (eta./(R + db) + yb.*q./(R + db).^2 - log(R + eta));
+			I = (1 - 2*nu)/2 * (eta/(R + db) + yb*q/(R + db)^2 - log(R + eta))
 		end
 		return I
 	end
 
 	function I4(db,eta,q,dip,nu,R)
 		if cos(dip) > eps()
-			I = (1 - 2*nu) * 1 ./ cos(dip) * (log(R + db) - sin(dip).*log(R + eta));
+			I = (1 - 2*nu) * 1 / cos(dip) * (log(R + db) - sin(dip)*log(R + eta))
 		else
-			I = -(1 - 2*nu) * q ./ (R + db);
+			I = -(1 - 2*nu) * q / (R + db)
 		end
 		return I
 	end
 
 	function I5(xi,eta,q,dip,nu,R,db)
-		X = sqrt(xi.^2 + q.^2);
+		X = sqrt(xi^2 + q^2)
 		if cos(dip) > eps()
-			I = (1 - 2*nu) * 2 ./ cos(dip) .* atan((eta.*(X + q.*cos(dip)) + X.*(R + X).*sin(dip)) ./(xi.*(R + X).*cos(dip)));
+			I = (1 - 2*nu) * 2 / cos(dip) * atan((eta*(X + q*cos(dip)) + X*(R + X)*sin(dip)) /(xi*(R + X)*cos(dip)))
 			if xi == 0
-				I = 0;
+				I = 0
 			end
 		else
-			I = -(1 - 2*nu) * xi.*sin(dip)./(R + db);
+			I = -(1 - 2*nu) * xi*sin(dip)/(R + db)
 		end
 		return I
 	end
@@ -775,16 +481,16 @@ module Okada
 	 strike-slip tilt subfunctions [equation (37) p. 1147]
 	"""
 	function uzx_ss(xi,eta,q,dip,nu)
-		R = sqrt.(xi.^2 + eta.^2 + q.^2);
-		u = -xi .* q .^ 2 .* A.(eta,R).*cos.(dip) + ((xi.*q)./R.^3 - K1.(xi,eta,q,dip,nu,R)).*sin.(dip);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		u = -xi * q ^ 2 * A(eta,R)*cos(dip) + ((xi*q)/R^3 - K1(xi,eta,q,dip,nu,R))*sin(dip)
 		return u
 	end
 
 	function uzy_ss(xi,eta,q,dip,nu)
-		R = sqrt.(xi.^2 + eta.^2 + q.^2);
-		db = eta.*sin(dip) - q.*cos(dip);
-		yb = eta.*cos(dip) + q.*sin(dip);
-		u = (db.*q./R.^3).*cos(dip) + (xi .^ 2 .* q.*A(eta,R).*cos(dip) - sin(dip)./R + yb.*q./R.^3 - K2(xi,eta,q,dip,nu,R)).*sin(dip);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		db = eta*sin(dip) - q*cos(dip)
+		yb = eta*cos(dip) + q*sin(dip)
+		u = (db*q/R^3)*cos(dip) + (xi ^ 2 * q*A(eta,R)*cos(dip) - sin(dip)/R + yb*q/R^3 - K2(xi,eta,q,dip,nu,R))*sin(dip)
 		return u
 	end
 
@@ -792,66 +498,62 @@ module Okada
 	 dip-slip tilt subfunctions [equation (38) p. 1147]
 	"""
 	function uzx_ds(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		db = eta.*sin(dip) - q.*cos(dip);
-		u = db.*q./R.^3 + q.*sin(dip)./(R.*(R + eta)) + K3(xi,eta,q,dip,nu,R).*sin(dip).*cos(dip);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		db = eta*sin(dip) - q*cos(dip)
+		u = db*q/R^3 + q*sin(dip)/(R*(R + eta)) + K3(xi,eta,q,dip,nu,R)*sin(dip)*cos(dip)
 		return u
 	end
 
 	function uzy_ds(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		db = eta.*sin(dip) - q.*cos(dip);
-		yb = eta.*cos(dip) + q.*sin(dip);
-		u = yb.*db.*q.*A(xi,R) 	- (2*db./(R.*(R + xi)) + xi.*sin(dip)./(R.*(R + eta))).*sin(dip) + K1(xi,eta,q,dip,nu,R).*sin(dip).*cos(dip);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		db = eta*sin(dip) - q*cos(dip)
+		yb = eta*cos(dip) + q*sin(dip)
+		u = yb*db*q*A(xi,R) 	- (2*db/(R*(R + xi)) + xi*sin(dip)/(R*(R + eta)))*sin(dip) + K1(xi,eta,q,dip,nu,R)*sin(dip)*cos(dip)
 		return u
 	end
 	"""
 	 tensile fault tilt subfunctions [equation (39) p. 1147]
 	"""
 	function uzx_tf(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		u = q .^ 2 ./R .^ 3 .* sin(dip) - q .^ 3 .*A(eta,R).*cos(dip) + K3(xi,eta,q,dip,nu,R).*sin(dip).^2;
+		R = sqrt(xi^2 + eta^2 + q^2)
+		u = q ^ 2 /R ^ 3 * sin(dip) - q ^ 3 *A(eta,R)*cos(dip) + K3(xi,eta,q,dip,nu,R)*sin(dip)^2
 		return u
 	end
 
 	function uzy_tf(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		db = eta.*sin(dip) - q.*cos(dip);
-		yb = eta.*cos(dip) + q.*sin(dip);
-		u = (yb.*sin(dip) + db.*cos(dip)).*q .^ 2 .*A(xi,R) + xi.*q .^ 2 .*A(eta,R).*sin(dip).*cos(dip) - (2*q./(R.*(R + xi)) - K1(xi,eta,q,dip,nu,R)).*sin(dip).^2;
+		R = sqrt(xi^2 + eta^2 + q^2)
+		db = eta*sin(dip) - q*cos(dip)
+		yb = eta*cos(dip) + q*sin(dip)
+		u = (yb*sin(dip) + db*cos(dip))*q ^ 2 *A(xi,R) + xi*q ^ 2 *A(eta,R)*sin(dip)*cos(dip) - (2*q/(R*(R + xi)) - K1(xi,eta,q,dip,nu,R))*sin(dip)^2
 		return u
 	end
 
-	function A(x,R)
-		a = (2*R + x)./(R .^ 3 .*(R + x).^2);
-		return a
-	end
+    A(x,R) = (2*R + x)/(R ^ 3 *(R + x)^2)
 
 	"""
 	 K... tilt subfunctions [equations (40) (41) p. 1148]
 	"""
 	function K1(xi,eta,q,dip,nu,R)
-		db = eta.*sin(dip) - q.*cos(dip);
+		db = eta*sin(dip) - q*cos(dip)
 		if cos(dip) > eps()
-			K = (1 - 2*nu) * xi./cos(dip) .* (1 ./ (R.*(R + db)) - sin(dip)./(R.*(R + eta)));
+			K = (1 - 2*nu) * xi/cos(dip) * (1 / (R*(R + db)) - sin(dip)/(R*(R + eta)))
 		else
-			K = (1 - 2*nu) * xi.*q./(R.*(R + db).^2);
+			K = (1 - 2*nu) * xi*q/(R*(R + db)^2)
 		end
 		return K
 	end
 
-	function K2(xi,eta,q,dip,nu,R)
-		K = (1 - 2*nu) * (-sin(dip)./R + q.*cos(dip)./(R.*(R + eta))) - K3(xi,eta,q,dip,nu,R);
-		return K
+	function K2(xi,eta,q,dip,nu,R) 
+		return (1 - 2*nu) * (-sin(dip)/R + q*cos(dip)/(R*(R + eta))) - K3(xi,eta,q,dip,nu,R)
 	end
 
 	function K3(xi,eta,q,dip,nu,R)
-		db = eta.*sin(dip) - q.*cos(dip);
-		yb = eta.*cos(dip) + q.*sin(dip);
+		db = eta*sin(dip) - q*cos(dip)
+		yb = eta*cos(dip) + q*sin(dip)
 		if cos(dip) > eps()
-			K = (1 - 2*nu) * 1 ./cos(dip) .* (q./(R.*(R + eta)) - yb./(R.*(R + db)));
+			K = (1 - 2*nu) * 1 /cos(dip) * (q/(R*(R + eta)) - yb/(R*(R + db)))
 		else
-			K = (1 - 2*nu) * sin(dip)./(R + db) .* (xi.^ 2 ./(R.*(R + db)) - 1);
+			K = (1 - 2*nu) * sin(dip)/(R + db) * (xi^ 2 /(R*(R + db)) - 1)
 		end
 		return K
 	end
@@ -862,28 +564,28 @@ module Okada
 	 strike-slip strain subfunctions [equation (31) p. 1145]
 	"""
 	function uxx_ss(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		u = xi .^ 2 .* q .* A(eta,R) - J1(xi,eta,q,dip,nu,R).*sin(dip);
+		R = sqrt(xi^2 + eta^2 + q^2);
+		u = xi ^ 2 * q * A(eta,R) - J1(xi,eta,q,dip,nu,R)*sin(dip)
 		return u
 	end
 
 	function uxy_ss(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		db = eta.*sin(dip) - q.*cos(dip);
-		u = xi .^3 .* db./(R .^ 3 .*(eta .^ 2 + q .^ 2))- (xi .^ 3 .*A(eta,R) + J2(xi,eta,q,dip,nu,R)).*sin(dip);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		db = eta*sin(dip) - q*cos(dip)
+		u = xi ^3 * db/(R ^ 3 *(eta ^ 2 + q ^ 2))- (xi ^ 3 *A(eta,R) + J2(xi,eta,q,dip,nu,R))*sin(dip)
 		return u
 	end
 
 	function uyx_ss(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		u = xi .* q ./ R .^ 3 .* cos(dip) + (xi .* q .^ 2 .* A(eta,R) - J2(xi,eta,q,dip,nu,R)).*sin(dip);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		u = xi * q / R ^ 3 * cos(dip) + (xi * q ^ 2 * A(eta,R) - J2(xi,eta,q,dip,nu,R))*sin(dip)
 		return u
 	end
 
 	function uyy_ss(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		yb = eta.*cos(dip) + q.*sin(dip);
-		u = yb .* q ./ R .^ 3 .* cos(dip) + (q .^ 3 .* A(eta,R).*sin(dip) - 2*q.*sin(dip)./(R.*(R + eta)) - (xi.^2 + eta.^2)./ R .^ 3 .* cos(dip) - J4(xi,eta,q,dip,nu,R)).*sin(dip);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		yb = eta*cos(dip) + q*sin(dip)
+		u = yb * q / R ^ 3 * cos(dip) + (q ^ 3 * A(eta,R)*sin(dip) - 2*q*sin(dip)/(R*(R + eta)) - (xi^2 + eta^2)/ R ^ 3 * cos(dip) - J4(xi,eta,q,dip,nu,R))*sin(dip)
 		return u
 	end
 
@@ -891,29 +593,29 @@ module Okada
 	 dip-slip strain subfunctions [equation (32) p. 1146]
 	"""
 	function uxx_ds(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		u = xi.*q./R.^3 + J3(xi,eta,q,dip,nu,R).*sin(dip).*cos(dip);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		u = xi*q/R^3 + J3(xi,eta,q,dip,nu,R)*sin(dip)*cos(dip)
 		return u
 	end
 
 	function uxy_ds(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		yb = eta.*cos(dip) + q.*sin(dip);
-		u = yb.*q./R.^3 - sin(dip)./R + J1(xi,eta,q,dip,nu,R).*sin(dip).*cos(dip);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		yb = eta*cos(dip) + q*sin(dip)
+		u = yb*q/R^3 - sin(dip)/R + J1(xi,eta,q,dip,nu,R)*sin(dip)*cos(dip)
 		return u
 	end
 
 	function uyx_ds(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		yb = eta.*cos(dip) + q.*sin(dip);
-		u = yb.*q./R.^3 + q.*cos(dip)./(R.*(R + eta)) + J1(xi,eta,q,dip,nu,R).*sin(dip).*cos(dip);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		yb = eta*cos(dip) + q*sin(dip)
+		u = yb*q/R^3 + q*cos(dip)/(R*(R + eta)) + J1(xi,eta,q,dip,nu,R)*sin(dip)*cos(dip)
 		return u
 	end
 
 	function uyy_ds(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		yb = eta.*cos(dip) + q.*sin(dip);
-		u = yb .^ 2 .* q .* A(xi,R) - (2*yb./(R.*(R + xi)) + xi.*cos(dip)./(R.*(R + eta))).*sin(dip) + J2(xi,eta,q,dip,nu,R).*sin(dip).*cos(dip);
+		R = sqrt(xi^2 + eta^2 + q^2)
+		yb = eta*cos(dip) + q*sin(dip)
+		u = yb ^ 2 * q * A(xi,R) - (2*yb/(R*(R + xi)) + xi*cos(dip)/(R*(R + eta)))*sin(dip) + J2(xi,eta,q,dip,nu,R)*sin(dip)*cos(dip)
 		return u
 	end
 
@@ -921,63 +623,61 @@ module Okada
 	 tensile fault strain subfunctions [equation (33) p. 1146]
 	"""
 	function uxx_tf(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		u = xi .* q .^ 2 .* A(eta,R) + J3(xi,eta,q,dip,nu,R).*sin(dip).^2;
+		R = sqrt(xi^2 + eta^2 + q^2)
+		u = xi * q ^ 2 * A(eta,R) + J3(xi,eta,q,dip,nu,R)*sin(dip)^2
 		return u
 	end
 
 	function uxy_tf(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		db = eta.*sin(dip) - q.*cos(dip);
-		u = -db.*q./ R .^ 3 - xi.^ 2 .*q.*A(eta,R).*sin(dip) + J1(xi,eta,q,dip,nu,R).*sin(dip).^2;
+		R = sqrt(xi^2 + eta^2 + q^2)
+		db = eta*sin(dip) - q*cos(dip)
+		u = -db*q/ R ^ 3 - xi^ 2 *q*A(eta,R)*sin(dip) + J1(xi,eta,q,dip,nu,R)*sin(dip)^2
 		return u
 	end
 
 	function uyx_tf(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		u = q .^ 2 ./R .^ 3 .*cos(dip) + q .^ 3 .* A(eta,R).*sin(dip) + J1(xi,eta,q,dip,nu,R).*sin(dip).^2;
+		R = sqrt(xi^2 + eta^2 + q^2)
+		u = q ^ 2 /R ^ 3 *cos(dip) + q ^ 3 * A(eta,R)*sin(dip) + J1(xi,eta,q,dip,nu,R)*sin(dip)^2
 		return u
 	end
 
 	function uyy_tf(xi,eta,q,dip,nu)
-		R = sqrt(xi.^2 + eta.^2 + q.^2);
-		db = eta.*sin(dip) - q.*cos(dip);
-		yb = eta.*cos(dip) + q.*sin(dip);
-		u = (yb .* cos(dip) - db.*sin(dip)) .* q .^ 2 .* A(xi,R) - q.*sin(2*dip)./(R.*(R + xi)) - (xi .* q .^ 2 .*A(eta,R) - J2(xi,eta,q,dip,nu,R)).*sin(dip).^2;
+		R = sqrt(xi^2 + eta^2 + q^2)
+		db = eta*sin(dip) - q*cos(dip)
+		yb = eta*cos(dip) + q*sin(dip)
+		u = (yb * cos(dip) - db*sin(dip)) * q ^ 2 * A(xi,R) - q*sin(2*dip)/(R*(R + xi)) - (xi * q ^ 2 *A(eta,R) - J2(xi,eta,q,dip,nu,R))*sin(dip)^2
 		return u
 	end
 
-	"
+	"""
 	 J... tensile fault subfunctions [equations (34) (35) p. 1146-1147]
-	"
+	"""
 	function J1(xi,eta,q,dip,nu,R)
-		db = eta.*sin(dip) - q.*cos(dip);
+		db = eta*sin(dip) - q*cos(dip)
 		if cos(dip) > eps()
-			J = (1 - 2*nu) * 1 ./cos(dip) * (xi .^ 2 ./(R.*(R + db).^2) - 1 ./(R + db)) - sin(dip)./cos(dip)*K3(xi,eta,q,dip,nu,R);
+			J = (1 - 2*nu) * 1 /cos(dip) * (xi ^ 2 /(R*(R + db)^2) - 1 /(R + db)) - sin(dip)/cos(dip)*K3(xi,eta,q,dip,nu,R)
 		else
-			J = (1 - 2*nu)/2 * q./(R + db).^2 .* (2 * xi .^ 2 ./(R.*(R + db)) - 1);
+			J = (1 - 2*nu)/2 * q/(R + db)^2 * (2 * xi ^ 2 /(R*(R + db)) - 1)
 		end
 		return J
 	end
 
 	function J2(xi,eta,q,dip,nu,R)
-		db = eta.*sin(dip) - q.*cos(dip);
-		yb = eta.*cos(dip) + q.*sin(dip);
+		db = eta*sin(dip) - q*cos(dip)
+		yb = eta*cos(dip) + q*sin(dip)
 		if cos(dip) > eps()
-			J = (1 - 2*nu) * 1 ./cos(dip) * xi.*yb./(R.*(R + db).^2) - sin(dip)./cos(dip)*K1(xi,eta,q,dip,nu,R);
+			J = (1 - 2*nu) * 1 /cos(dip) * xi*yb/(R*(R + db)^2) - sin(dip)/cos(dip)*K1(xi,eta,q,dip,nu,R)
 		else
-			J = (1 - 2*nu)/2 * xi.*sin(dip)./(R + db).^ 2 .* (2*q .^ 2 ./(R.*(R + db)) - 1);
+			J = (1 - 2*nu)/2 * xi*sin(dip)/(R + db)^ 2 * (2*q ^ 2 /(R*(R + db)) - 1)
 		end
 		return J
 	end
 
-	function J3(xi,eta,q,dip,nu,R)
-		J = (1 - 2*nu) * -xi./(R.*(R + eta)) - J2(xi,eta,q,dip,nu,R);
-		return J
+	function J3(xi,eta,q,dip,nu,R) 
+		return (1 - 2*nu) * -xi/(R*(R + eta)) - J2(xi,eta,q,dip,nu,R)
 	end
 
-	function J4(xi,eta,q,dip,nu,R)
-		J = (1 - 2*nu) * (-cos(dip)./R - q.*sin(dip)./(R.*(R + eta))) - J1(xi,eta,q,dip,nu,R);
-		return J
+	function J4(xi,eta,q,dip,nu,R) 
+		return (1 - 2*nu) * (-cos(dip)/R - q*sin(dip)/(R*(R + eta))) - J1(xi,eta,q,dip,nu,R)
 	end
 end

--- a/Okada.jl
+++ b/Okada.jl
@@ -147,7 +147,7 @@ module Okada
 		Created: 1997
 		Updated: 2014-05-24
 		"""
-	function Okada85(e,n,depth,strike,dip,L,W,rake,slip,U3)
+	function Okada85(e,n,depth,strike,dip,L,W,rake,slip,U3; nu=0.25)
 
 		if(depth<W*0.5*sind(dip))
 			warn("Depth too shallow! ")
@@ -156,7 +156,6 @@ module Okada
 		strike = strike*pi/180;	# converting STRIKE in radian
 		dip = dip*pi/180;	# converting DIP in radian ('delta' in Okada's equations)
 		rake = rake*pi/180;	#converting RAKE in radian
-		nu = 0.25;
 
 		# Defines dislocation in the fault plane system
 		U1 = cos(rake).*slip;
@@ -233,12 +232,11 @@ module Okada
 
 	end
 
-	function Okada85vert(e,n,depth,strike,dip,L,W,rake,slip,U3)
+	function Okada85vert(e,n,depth,strike,dip,L,W,rake,slip,U3; nu=0.25)
 
 		strike = strike*pi/180;	# converting STRIKE in radian
 		dip = dip*pi/180;	# converting DIP in radian ('delta' in Okada's equations)
 		rake = rake*pi/180;	#converting RAKE in radian
-		nu = 0.25;
 
 		# Defines dislocation in the fault plane system
 		U1 = cos(rake).*slip;
@@ -314,12 +312,11 @@ module Okada
 
 
 	end
-	function Okada85Dis(e,n,depth,strike,dip,L,W,rake,slip,U3)
+	function Okada85Dis(e,n,depth,strike,dip,L,W,rake,slip,U3; nu=0.25)
 
 		strike = strike*pi/180;	# converting STRIKE in radian
 		dip = dip*pi/180;	# converting DIP in radian ('delta' in Okada's equations)
 		rake = rake*pi/180;	#converting RAKE in radian
-		nu = 0.25;
 
 		# Defines dislocation in the fault plane system
 		U1 = cos(rake).*slip;

--- a/Okada.jl
+++ b/Okada.jl
@@ -2,10 +2,10 @@
 """
     Okada 1985 Surface deformation due to a finite rectangular source.
 
-	Okada85(E,N,DEPTH,STRIKE,DIP,LENGTH,WIDTH,RAKE,SLIP,OPEN)
+	okada85(E,N,DEPTH,STRIKE,DIP,LENGTH,WIDTH,RAKE,SLIP,OPEN)
 
 	Work in progress...
-	uE,uN,uZ = OKADA85(...) displacements only;
+	uE,uN,uZ = okada85(...) displacements only;
 
 	References:
 	   Aki K., and P. G. Richards, Quantitative seismology, Freemann & Co,
@@ -19,7 +19,7 @@
 """
 module Okada
 
-	export Okada85, testOkada
+	export okada85, testokada
 	
 	#	Translated to Julia By Cyprien Bosserelle 2020
 	#	References:
@@ -147,7 +147,7 @@ module Okada
 		Created: 1997
 		Updated: 2014-05-24
 		"""
-	function Okada85(e,n,depth,strike,dip,L,W,rake,slip,U3; nu=0.25, nargout::Integer=3)
+	function okada85(e,n,depth,strike,dip,L,W,rake,slip,U3; nu=0.25, nargout::Integer=3)
 
 		## arg check
         any(nargout .== [1,3,9,12]) || error("kwarg 'nargout' must be either 1, 3, 9, or 12.")
@@ -250,14 +250,14 @@ module Okada
 	import Test
 	function runtest(x,y,d,dip,L,W,rake,slip,u3,ref, precision)
 
-	    ue,un,uz,uze,uzn,unn,une,uen,uee=Okada85(x-L/2,y-cosd(dip)*W/2,d-sind(dip)*W/2,90,dip,L,W,rake,slip,u3; nargout=9)
+	    ue,un,uz,uze,uzn,unn,une,uen,uee=okada85(x-L/2,y-cosd(dip)*W/2,d-sind(dip)*W/2,90,dip,L,W,rake,slip,u3; nargout=9)
 	    return Test.@test [ue,un,uz,uee,uen,une,unn,uze,uzn] ≈ ref atol=precision
 	end
 
 	"""
 	Test function for Okada
 	"""
-	function testOkada()
+	function testokada()
 		# ###################
 		# ##### TEST
 		# ####################
@@ -351,7 +351,6 @@ module Okada
 	function ux_ss(xi,eta,q,dip,nu)
 		R = sqrt(xi^2 + eta^2 + q^2)
 		u = xi*q/(R*(R + eta)) + I1(xi,eta,q,dip,nu,R)*sin(dip)
-		k = findall(q.!=0)
 		if q!=0
 			u = u + atan(xi*eta/(q*R))
 		end

--- a/Tsunami.jl
+++ b/Tsunami.jl
@@ -9,7 +9,7 @@
 module Tsunami
 
     import Okada,NetCDF
-    export InitTsunamiGeo,InitTsunami,faultparam,faultkm2m!,rotatexy,unrotatexy,unrotatexyCompass,rotatexyCompass,sphericDist,sphericOffset,mvBLref2centroid!,emptygrid,cartsphdist2eq,cartdistance2eq,CalcMw,Mw2slip,Calcslip!,Okadavert
+    export InitTsunamiGeo,InitTsunami,faultparam,faultkm2m!,rotatexy,unrotatexy,unrotatexyCompass,rotatexyCompass,sphericDist,sphericOffset,mvBLref2centroid!,emptygrid,cartsphdist2eq,cartdistance2eq,CalcMw,Mw2slip,Calcslip!
 
 """
 Fault parameter structure to simplify tsunami generation from earthquake
@@ -286,7 +286,7 @@ Generate tsunami initial wave for a Geographical domain (i.e. lat and lon coordi
         dHdy[:,2:end]=diff(H,dims=2)./diff(nf,dims=2);
 
         # Calculate horizontal and vertical deformation
-        uX,uY,uZ=Okada.Okada85Dis(ef,nf,fault.depth,fault.strike,fault.dip,fault.length,fault.width,fault.rake,fault.slip,0);
+        uX,uY,uZ = Okada.okada85(ef,nf,fault.depth,fault.strike,fault.dip,fault.length,fault.width,fault.rake,fault.slip,0; nargout=3)
 
         dz = uZ .+ uX .* dHdx .+ uY .* dHdy
 
@@ -316,7 +316,7 @@ Generate tsunami initial wave for a Geographical domain (i.e. lat and lon coordi
             dHdy[:,2:end]=diff(H,dims=2)./diff(nf,dims=2);
 
             # Calculate horizontal and vertical deformation
-            uX,uY,uZ=Okada.Okada85Dis(ef,nf,fault.depth,fault.strike,fault.dip,fault.length,fault.width,fault.rake,fault.slip,0);
+            uX,uY,uZ = Okada.okada85(ef,nf,fault.depth,fault.strike,fault.dip,fault.length,fault.width,fault.rake,fault.slip,0; nargout=3)
 
             dz = uZ .+ uX .* dHdx .+ uY .* dHdy
 


### PR DESCRIPTION
Major updates are as follows:
- Move Poisson's ratio `nu` to a keyword argument.
- Simplify Chinnery's notation part. 
- Rename `Okada85` to `okada85` (lower case) following [Julia style guide](https://docs.julialang.org/en/v1/manual/style-guide/) 
- Integrate functions `Okada85vert` and `Okada85Dis` into `okada85`; the number of output arguments is specified by the keyword argument `nargout`.

The last item is just a matter of preference. Please let me know if you have any suggestions.